### PR TITLE
Dockerfile: Update base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.5-alpine3.12 as builder
+FROM golang:1.19-alpine3.16 as builder
 
 # Set workdir
 WORKDIR /sources
@@ -13,7 +13,7 @@ RUN make build
 
 # ----------------------------
 
-FROM alpine:3.12
+FROM alpine:3.16
 
 COPY --from=builder /sources/build/ /usr/local/bin/
 


### PR DESCRIPTION
Alpine base image is being updated from v3.12 (end of support 2022-05-01; already passed) to v3.16 (end of support 2024-05-23).

The base Go image is being updated from 1.15.5 (released 2020-11-12; superseded by 10 patch releases) to 1.19.x (current latest version).