### PR TITLE
Allow configuring global LogLevel

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ tenderseed start
 
 **This will seed/crawl cosmoshub-4**
 ```bash
-tenderseed -seed=bf8328b66dceb4987e5cd94430af66045e59899f@public-seed.cosmos.vitwit.com:26656,cfd785a4224c7940e9a10f6c1ab24c343e923bec@164.68.107.188:26656,d72b3011ed46d783e369fdf8ae2055b99a1e5074@173.249.50.25:26656,ba3bacc714817218562f743178228f23678b2873@public-seed-node.cosmoshub.certus.one:26656,3c7cad4154967a294b3ba1cc752e40e8779640ad@84.201.128.115:26656,366ac852255c3ac8de17e11ae9ec814b8c68bddb@51.15.94.196:26656 -chain-id cosmoshub-4 start
+tenderseed -seeds=bf8328b66dceb4987e5cd94430af66045e59899f@public-seed.cosmos.vitwit.com:26656,cfd785a4224c7940e9a10f6c1ab24c343e923bec@164.68.107.188:26656,d72b3011ed46d783e369fdf8ae2055b99a1e5074@173.249.50.25:26656,ba3bacc714817218562f743178228f23678b2873@public-seed-node.cosmoshub.certus.one:26656,3c7cad4154967a294b3ba1cc752e40e8779640ad@84.201.128.115:26656,366ac852255c3ac8de17e11ae9ec814b8c68bddb@51.15.94.196:26656 -chain-id cosmoshub-4 start
 ```
 
 To view your node id (you will need this for other nodes to connect), invoke the `show-node-id` command.
@@ -65,6 +65,9 @@ chain_id = "some-chain-id"
 
 # Address to listen for incoming connections
 laddr = "tcp://0.0.0.0:26656"
+
+# logging level to filter output ("info", "debug", "error" or "none")
+log_level = "info"
 
 # maximum number of inbound connections
 max_num_inbound_peers = 1000

--- a/cmd/tenderseed/main.go
+++ b/cmd/tenderseed/main.go
@@ -23,7 +23,6 @@ func main() {
 	configFile := flag.String("config", "config/config.toml", "path to configuration file within home directory")
 	chainID := flag.String("chain-id", "", "chain id")
 	seeds := flag.String("seeds", "", "comma separated list of seeds")
-	logLevel := flag.String("log-level", "", "logging level to filter output (\"info\", \"debug\", \"error\" or \"none\")")
 			     
 	// parse top level flags
 	flag.Parse()
@@ -36,12 +35,11 @@ func main() {
 		panic(err)
 	}
 	
-	// Get chain-id, seeds, log-level from ENV
+	// Get chain-id, seeds from ENV
         env_chainid, env_chainid_ok := os.LookupEnv("TENDERSEED_CHAIN_ID")
         env_seeds, env_seeds_ok := os.LookupEnv("TENDERSEED_SEEDS")
-        env_loglevel, env_loglevel_ok := os.LookupEnv("TENDERSEED_LOG_LEVEL")
 
-        // Set chain-id, seeds, log-level from ARGS or ENV
+        // Set chain-id, seeds from ARGS or ENV
         if *chainID != ""  {
             seedConfig.ChainID = *chainID
         } else if env_chainid_ok {
@@ -51,11 +49,6 @@ func main() {
             seedConfig.Seeds = *seeds
 	} else if env_seeds_ok {
              seedConfig.Seeds = env_seeds
-        }
-        if *logLevel != "" {
-            seedConfig.LogLevel = *logLevel
-	} else if env_loglevel_ok {
-             seedConfig.LogLevel = env_loglevel
         }
 
         if seedConfig.ChainID == "" || seedConfig.Seeds == "" {

--- a/cmd/tenderseed/main.go
+++ b/cmd/tenderseed/main.go
@@ -23,6 +23,7 @@ func main() {
 	configFile := flag.String("config", "config/config.toml", "path to configuration file within home directory")
 	chainID := flag.String("chain-id", "", "chain id")
 	seeds := flag.String("seeds", "", "comma separated list of seeds")
+	logLevel := flag.String("log-level", "", "logging level to filter output (\"info\", \"debug\", \"error\" or \"none\")")
 			     
 	// parse top level flags
 	flag.Parse()
@@ -35,11 +36,12 @@ func main() {
 		panic(err)
 	}
 	
-	// Get chain-id, seeds-nodes from ENV
+	// Get chain-id, seeds, log-level from ENV
         env_chainid, env_chainid_ok := os.LookupEnv("TENDERSEED_CHAIN_ID")
         env_seeds, env_seeds_ok := os.LookupEnv("TENDERSEED_SEEDS")
+        env_loglevel, env_loglevel_ok := os.LookupEnv("TENDERSEED_LOG_LEVEL")
 
-        // Set chain-id, seeds-nodes from ARGS or ENV
+        // Set chain-id, seeds, log-level from ARGS or ENV
         if *chainID != ""  {
             seedConfig.ChainID = *chainID
         } else if env_chainid_ok {
@@ -49,6 +51,11 @@ func main() {
             seedConfig.Seeds = *seeds
 	} else if env_seeds_ok {
              seedConfig.Seeds = env_seeds
+        }
+        if *logLevel != "" {
+            seedConfig.LogLevel = *logLevel
+	} else if env_loglevel_ok {
+             seedConfig.LogLevel = env_loglevel
         }
 
         if seedConfig.ChainID == "" || seedConfig.Seeds == "" {

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -85,6 +85,7 @@ func (args *StartArgs) Execute(_ context.Context, flagSet *flag.FlagSet, _ ...in
 		"key", nodeKey.ID(),
 		"listen", args.SeedConfig.ListenAddress,
 		"chain", chainID,
+		"log-level", args.SeedConfig.LogLevel,
 		"strict-routing", args.SeedConfig.AddrBookStrict,
 		"max-inbound", args.SeedConfig.MaxNumInboundPeers,
 		"max-outbound", args.SeedConfig.MaxNumOutboundPeers,
@@ -92,7 +93,11 @@ func (args *StartArgs) Execute(_ context.Context, flagSet *flag.FlagSet, _ ...in
 	)
 
 	// TODO(roman) expose per-module log levels in the config
-	filteredLogger := log.NewFilter(logger, log.AllowInfo())
+	logOption, err := log.AllowLevel(args.SeedConfig.LogLevel)
+	if err != nil {
+		panic(err)
+	}
+	filteredLogger := log.NewFilter(logger, logOption)
 
 	protocolVersion :=
 		p2p.NewProtocolVersion(

--- a/internal/tenderseed/Config.go
+++ b/internal/tenderseed/Config.go
@@ -12,6 +12,7 @@ import (
 type Config struct {
 	ListenAddress           string   `toml:"laddr" comment:"Address to listen for incoming connections"`
 	ChainID                 string   `toml:"chain_id" comment:"network identifier (todo move to cli flag argument? keeps the config network agnostic)"`
+	LogLevel                string   `toml:"log_level" comment:"logging level to filter output (\"info\", \"debug\", \"error\" or \"none\")"`
 	NodeKeyFile             string   `toml:"node_key_file" comment:"path to node_key (relative to tendermint-seed home directory or an absolute path)"`
 	AddrBookFile            string   `toml:"addr_book_file" comment:"path to address book (relative to tendermint-seed home directory or an absolute path)"`
 	AddrBookStrict          bool     `toml:"addr_book_strict" comment:"Set true for strict routability rules\n Set false for private or local networks"`
@@ -69,6 +70,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		ListenAddress:           "tcp://0.0.0.0:26656",
 		ChainID:                 "",
+		LogLevel:                "info",
 		NodeKeyFile:             "config/node_key.json",
 		AddrBookFile:            "data/addrbook.json",
 		AddrBookStrict:          true,


### PR DESCRIPTION
There is a potential TODO being left where it was for controlling the logging level per module. But for many people, just setting a global "error" log level is helpful - they are not interested in seeing verbose output about which peer has been reached successfully, considering there are many connections being established per second.

Ref: [tendermint@v0.34.24/libs/log/filter.go](https://github.com/tendermint/tendermint/blob/v0.34.24/libs/log/filter.go#L134)